### PR TITLE
llm_client_backend: add object type to completion marker

### DIFF
--- a/backend/llm_client_backend.py
+++ b/backend/llm_client_backend.py
@@ -284,6 +284,7 @@ class LlmClientBackend(BaseModelBackend):
                             }
                         # Add normal completion marker
                         yield {
+                            "object": "chat.completion.chunk",
                             "choices": [{
                                 "delta": {},
                                 "finish_reason": "stop"


### PR DESCRIPTION
The OpenAI chat completion API shows that streaming chat completion chunks should have the object type "chat.completion.chunk" in the completion marker chunk.  Without this, some parsers of the OpenAI API don't handle chat completion streaming responses from this server.

This commit fixes the lack of an object type, keeps compliance with the described API in the OpenAI docs (see
https://platform.openai.com/docs/api-reference/chat/create), and ensures parsers like the Home Assistant HomeLLM addon work with it.